### PR TITLE
Fix alias and remove unused var XPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 `npm run build`
 
 
-Note: `addon.xpi` is a symbolic link to the extension's true XPI, which is named based on the study's unique addon ID specified in `package.json`.
+Note: `linked-addon.xpi` is a symbolic link to the extension's true XPI, which is named based on the study's unique addon ID specified in `package.json`.
 
 at second shell/prompt, watch files for changes to rebuild:
 

--- a/bin/xpi.sh
+++ b/bin/xpi.sh
@@ -27,7 +27,8 @@ function cleanup {
 trap cleanup EXIT
 
 # fill templates, could be fancier
-alias moustache='/node_modules/bin/mustache'
+shopt -s expand_aliases
+alias mustache='./node_modules/.bin/mustache'
 echo 'Filling mustache template files...'
 mustache package.json templates/install.rdf.mustache > addon/install.rdf
 mustache package.json templates/chrome.manifest.mustache > addon/chrome.manifest
@@ -49,7 +50,7 @@ rm -f linked-addon.xpi
 ln -s "${XPI_NAME}" linked-addon.xpi
 
 echo
-echo "SUCCESS: xpi at ${BASE_DIR}/dist/${XPI}"
+echo "SUCCESS: xpi at ${BASE_DIR}/dist/${XPI_NAME}"
 echo "SUCCESS: symlinked xpi at ${BASE_DIR}/dist/linked-addon.xpi"
 
 popd > /dev/null

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "eslint .",
     "eslint": "eslint addon --ext jsm --ext js --ext json --",
     "prebuild": "cp node_modules/shield-studies-addon-utils/dist/StudyUtils.jsm addon/",
-    "build": "XPI=shield-embedded-web-extension.xpi bash ./bin/xpi.sh",
+    "build": "bash ./bin/xpi.sh",
     "test": "export XPI_NAME=dist/linked-addon.xpi && npm run build && mocha test/functional_tests.js --retry 2",
     "harness_test": "export XPI_NAME=dist/linked-addon.xpi && mocha test/functional_tests.js --retry 2 --reporter json",
     "firefox": "export XPI_NAME=dist/linked-addon.xpi && npm run build && node manual_test.js",


### PR DESCRIPTION
* Alias command now expands correctly, so the command in 'npm build' ('bash ./bin/xpi.sh') now works on the command line as well as in the xpi.sh script. TIL: Aliases are not expanded by default in non-interactive shells.
* Seems like XPI variable is not used? Removed unused variable 'XPI' in 'package.json' and in 'xpi.sh'
* Updated `addon.xpi` in README with `linked-addon.xpi` per [this comment](https://github.com/gregglind/template-shield-study/pull/4#discussion_r138947261)